### PR TITLE
chore: add remark preset package links

### DIFF
--- a/packages/remark-preset/package.json
+++ b/packages/remark-preset/package.json
@@ -18,6 +18,10 @@
 		"url": "git+https://github.com/AlexAegis/js-tooling.git",
 		"type": "git"
 	},
+	"homepage": "https://github.com/AlexAegis/js-tooling/tree/master/packages/remark-preset#readme",
+	"bugs": {
+		"url": "https://github.com/AlexAegis/js-tooling/issues"
+	},
 	"type": "module",
 	"publishConfig": {
 		"access": "public",


### PR DESCRIPTION
## Summary

- Add package-local `homepage` metadata for `@alexaegis/remark-preset`.
- Add standard npm `bugs.url` metadata pointing to the repository issue tracker.

## Reproduction

Current published metadata for `@alexaegis/remark-preset@0.15.2` exposes repository and license, but no `homepage` or `bugs` fields:

```sh
npm view @alexaegis/remark-preset@0.15.2 name version repository homepage bugs license --json
```

## Validation

```sh
node -e "const p=require('./packages/remark-preset/package.json'); if (p.homepage !== 'https://github.com/AlexAegis/js-tooling/tree/master/packages/remark-preset#readme') throw new Error('bad homepage'); if (p.bugs?.url !== 'https://github.com/AlexAegis/js-tooling/issues') throw new Error('bad bugs'); if (p.repository.url !== 'git+https://github.com/AlexAegis/js-tooling.git') throw new Error('repository changed'); console.log('remark-preset metadata ok')"
git diff --check
```

This is metadata-only; no runtime code, dependencies, package version, exports, or build behavior changed.
